### PR TITLE
feat: Managing speos lightbox import in scene

### DIFF
--- a/src/ansys/api/speos/scene/v2/scene.proto
+++ b/src/ansys/api/speos/scene/v2/scene.proto
@@ -408,7 +408,7 @@ message Scene
 
 	string part_guid = 10; // Guid from PartsManager of the geometrical part included inside the scene
 	
-	repeated double anchor_axis_system = 11; // Represents the axis system to be attached to the one describing the scene instance. If the coordinate system is not orthonormal, it will be automatically orthonormalized
+	repeated double sub_scene_anchor_axis_system = 11; // Only used for sub-scene - Represents the axis system to be attached to the one describing the scene instance. If the coordinate system is not orthonormal, it will be automatically orthonormalized
 	
 	repeated SourceInstance sources = 13; // The sources added in the scene
 	repeated SensorInstance sensors = 14; // The sensors added in the scene


### PR DESCRIPTION
Only used for sub-scene, we add an axis system representing the axis system to be attached to the one describing the scene instance.
Overloading the method LoadFile in SceneAction service to load .SPEOSLightBox file.
Adding field password in LoadFile_Request message to enter an passwork needed to open .SPEOSLightBox file.