### PR TITLE
feat: add display_name field

### DIFF
--- a/src/ansys/api/speos/part/v1/body.proto
+++ b/src/ansys/api/speos/part/v1/body.proto
@@ -6,7 +6,8 @@ package ansys.api.speos.body.v1;
 // Body definition made of faces
 message Body
 {
-	string name = 1;
+	string name = 1; // Unique identifier in its Body
+	string display_name = 6; // User name to be displayed
 	string description = 2;
 	map<string, string> metadata = 4; // User defined metadata
 	repeated string face_guids = 5; // List of faces constituting the body

--- a/src/ansys/api/speos/part/v1/body.proto
+++ b/src/ansys/api/speos/part/v1/body.proto
@@ -6,7 +6,7 @@ package ansys.api.speos.body.v1;
 // Body definition made of faces
 message Body
 {
-	string name = 1; // Unique identifier in its Body
+	string name = 1; // Unique identifier in its Part
 	string display_name = 6; // User name to be displayed
 	string description = 2;
 	map<string, string> metadata = 4; // User defined metadata

--- a/src/ansys/api/speos/part/v1/face.proto
+++ b/src/ansys/api/speos/part/v1/face.proto
@@ -6,7 +6,8 @@ package ansys.api.speos.face.v1;
 // Face definition with meshing information
 message Face
 {
-	string name = 1;
+	string name = 1; // Unique identifier in its Body
+	string display_name = 4; // User name to be displayed
 	string description = 2;
 	map<string, string> metadata = 3; // user defined metadata
 	repeated float vertices = 10; // coordinates of all points (p1x p1y p1z p2x p2y p2z ...)
@@ -93,6 +94,7 @@ message Chunk {
 	message FaceHeader {
 		string guid = 1; // Guid of a FacesManager element - Used for FaceActions.Upload rpc
 		string name = 2;
+		string display_name = 6;
 		string description = 3;
 		map<string, string> metadata = 4;
 		repeated int32 sizes = 5; // total sizes for vectors: (vertices_normals_size, facets_size, texture_coordinates_channels_size) - vertices and normals vectors have same size, that's why it is gathered in vertices_normals_size

--- a/src/ansys/api/speos/part/v1/part.proto
+++ b/src/ansys/api/speos/part/v1/part.proto
@@ -9,7 +9,8 @@ message Part
 	// Instance of Part in parent coordinates system
 	message PartInstance
 	{
-		string name = 1;
+		string name = 1; // Unique identifier in its Part
+		string display_name = 4; // User name to be displayed
 		string description = 2;
 		string part_guid = 3; // Guid of Part in PartsManager
 		repeated double axis_system = 11; // Part position relative to parent reference (Ox Oy Oz Xx Xy Xz Yx Yy Yz Zx Zy Zz) 

--- a/src/ansys/api/speos/scene/v1/scene.proto
+++ b/src/ansys/api/speos/scene/v1/scene.proto
@@ -21,7 +21,7 @@ message Scene
 	// Instance of a VOP to apply on geometries of the scene
 	message VOPInstance
 	{
-		string name = 1; // Unique identifier in the scene
+		string name = 1;
 		string description = 2;
 		map<string, string> metadata = 3; // User defined metadata
 		string vop_guid = 10; // Guid of the element to instantiate
@@ -31,7 +31,7 @@ message Scene
 	// Instance of a SOP to apply on geometries of the scene
 	message SOPInstance
 	{
-		string name = 1; // Unique identifier in the scene
+		string name = 1;
 		string description = 2;
 		map<string, string> metadata = 3; // User defined metadata
 		string sop_guid = 10; // Guid of the element to instantiate

--- a/src/ansys/api/speos/scene/v1/scene.proto
+++ b/src/ansys/api/speos/scene/v1/scene.proto
@@ -21,7 +21,8 @@ message Scene
 	// Instance of a VOP to apply on geometries of the scene
 	message VOPInstance
 	{
-		string name = 1;
+		string name = 1; // Unique identifier in the scene
+		string display_name = 4; // User name to be displayed
 		string description = 2;
 		map<string, string> metadata = 3; // User defined metadata
 		string vop_guid = 10; // Guid of the element to instantiate
@@ -31,7 +32,8 @@ message Scene
 	// Instance of a SOP to apply on geometries of the scene
 	message SOPInstance
 	{
-		string name = 1;
+		string name = 1; // Unique identifier in the scene
+		string display_name = 4; // User name to be displayed
 		string description = 2;
 		map<string, string> metadata = 3; // User defined metadata
 		string sop_guid = 10; // Guid of the element to instantiate

--- a/src/ansys/api/speos/scene/v2/scene.proto
+++ b/src/ansys/api/speos/scene/v2/scene.proto
@@ -31,7 +31,8 @@ message Scene
 	// Instance of a Material to apply on geometries of the scene
 	message MaterialInstance
 	{
-		string name = 1;
+		string name = 1; // Unique identifier in the scene
+		string display_name = 4; // User name to be displayed
 		string description = 2;
 		map<string, string> metadata = 3; // User defined metadata
 		optional string vop_guid = 10; // optional - Guid of the volume optical property to instantiate
@@ -92,7 +93,8 @@ message Scene
 			GeoPaths exit_geometries = 2; // Exit Geometries that will use this rayfile source 
 		}
 
-		string name = 1;
+		string name = 1; // Unique identifier in the scene
+		string display_name = 4; // User name to be displayed
 		string description = 2;
 		map<string, string> metadata = 3; // User defined metadata
 		string source_guid = 10; // Guid of the SourceTemplate in SourceTemplatesManager to instantiate
@@ -183,7 +185,8 @@ message Scene
 			}
 		}
 
-		string name = 1;
+		string name = 1; // Unique identifier in the scene
+		string display_name = 4; // User name to be displayed
 		string description = 2;
 		map<string, string> metadata = 3; // User defined metadata
 		string sensor_guid = 10; // Guid of the SensorTemplate in SensorTemplatesManager to instantiate
@@ -198,7 +201,8 @@ message Scene
 	// Instance of a simulation to add in the scene
 	message SimulationInstance
 	{
-		string name = 1;
+		string name = 1; // Unique identifier in the scene
+		string display_name = 4; // User name to be displayed
 		string description = 2;
 		map<string, string> metadata = 3; // User defined metadata
 		string simulation_guid = 10; // Guid of the element to instantiate
@@ -209,7 +213,8 @@ message Scene
 
 	message SceneInstance
 	{
-		string name = 1;
+		string name = 1; // Unique identifier in the scene
+		string display_name = 4; // User name to be displayed
 		string description = 2;
 		map<string, string> metadata = 3; // User defined metadata
 		string scene_guid = 10; // Guid of the element to instantiate


### PR DESCRIPTION
Add display_name for all instances fields. This message is not mandatory, but will set the name of the Speos objects in case it is set.
The name field is still used to retrieve the instances in the scene.