### PR TITLE
fix setuptool version to < 67.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools >= 42.0.0", "wheel", "ansys_tools_protoc_helper>=0.4.0"]
+requires = ["setuptools < 67.0.0", "wheel", "ansys_tools_protoc_helper>=0.4.0"]
 build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
setuptools latest releases are now also leveraging PEP639, so limit max version to less than 67.0.0