### PR TITLE
fix: Fix integration direction comments for irradiance sensors

### DIFF
--- a/src/ansys/api/speos/scene/v2/scene.proto
+++ b/src/ansys/api/speos/scene/v2/scene.proto
@@ -257,7 +257,7 @@ message Scene
 				LayerTypePolarization layer_type_polarization = 7; // Layer type : Polarization
 				LayerTypeIncidenceAngle layer_type_incidence_angle = 8; // Layer type : Incidence angle
 			}
-			repeated double integration_direction = 9; // Sensor global integration direction [x,y,z], optional (default direction is Z axis of axis_system), must be set in the anti-rays direction to integrate their signal, and only settable for sensor template with IlluminanceTypePlanar or IlluminanceTypeSemiCylindrical as illuminance_type
+			repeated double integration_direction = 9; // Sensor global integration direction [x,y,z], optional (default direction is Z axis of axis_system). Note: Contrary to any visualization of integration directions within Speos Software or its documentation the integration direction must be set in the anti-rays direction to integrate their signal. Integration direction is only settable for sensor template with IlluminanceTypePlanar or IlluminanceTypeSemiCylindrical as illuminance_type.
 			GeoPaths output_face_geometries = 10; // List of output faces for inverse simulation optimization
 		}
 		message RadianceProperties {

--- a/src/ansys/api/speos/scene/v2/scene.proto
+++ b/src/ansys/api/speos/scene/v2/scene.proto
@@ -257,7 +257,7 @@ message Scene
 				LayerTypePolarization layer_type_polarization = 7; // Layer type : Polarization
 				LayerTypeIncidenceAngle layer_type_incidence_angle = 8; // Layer type : Incidence angle
 			}
-			repeated double integration_direction = 9; // Sensor global integration direction [x,y,z], optional (default direction is normal to sensor plane (anti-normal of the sensor)) and only settable for sensor template with IlluminanceTypePlanar or IlluminanceTypeSemiCylindrical as illuminance_type
+			repeated double integration_direction = 9; // Sensor global integration direction [x,y,z], optional (default direction is Z axis of axis_system), must be set in the anti-rays direction to integrate their signal, and only settable for sensor template with IlluminanceTypePlanar or IlluminanceTypeSemiCylindrical as illuminance_type
 			GeoPaths output_face_geometries = 10; // List of output faces for inverse simulation optimization
 		}
 		message RadianceProperties {


### PR DESCRIPTION
Comments about irradiance sensor integration direction didn't represents what the RPC Server was doing. The aim of this PR is to explain its behavior :

- When integration_direction is not set, the default integration direction is the z axis of sensor axissytem.
- integration_direction must point toward the rays to integrate signal