### PR TITLE
fix: Improve source group comment in 0.16

### DIFF
--- a/src/ansys/api/speos/scene/v2/scene.proto
+++ b/src/ansys/api/speos/scene/v2/scene.proto
@@ -390,7 +390,7 @@ message Scene
 		string simulation_guid = 10; // Guid of the element to instantiate
 		repeated string sensor_paths = 11; // Sensors that this simulation will include (empty for no sensor, [""] for all sensors, "<sensor name>" for a specific sensor in the current scene, or "<scene name>/<sensor name>" for a specific sensor in a specific sub scene)
 		repeated string source_paths = 12; // Sources that this simulation will include (empty for no source, [""] for all sources, "<source name>" for a specific source in the current scene, or "<scene name>/<source name>" for a specific source in a specific sub scene)
-		repeated SourceGroup source_groups = 15; // Source groups that this simulation will include, all sources with a same group name will be added to the same layer when sensor layering is LayerTypeSource
+		repeated SourceGroup source_groups = 15; // Source groups that this simulation will include, only sources which are in source_path can be added to a source group. All sources with in one source group will be grouped in one layer in the result, when sensor layering is LayerTypeSource.
 		GeoPaths geometries = 13; // Geometries that this simulation will include - Not yet functional (All geometries are included by default in each simulation)
 		oneof properties {
 			VirtualBSDFBenchProperties vbb_properties = 14; // To be filled if the simulation_guid corresponds to a SimulationTemplate of type VirtualBSDFBench


### PR DESCRIPTION
Improve comment about source group to explicitely explain source group field is only used for source grouping, no source selection

cherry pick from https://github.com/ansys/ansys-api-speos/pull/160