### PR TITLE
feat: Scene - LoadFile - Add indication about metadata ForceSensorTemplateV1

### DIFF
--- a/src/ansys/api/speos/scene/v2/scene.proto
+++ b/src/ansys/api/speos/scene/v2/scene.proto
@@ -385,7 +385,7 @@ message Scene
 		string description = 2;
 		map<string, string> metadata = 3; // User defined metadata
 		string sensor_guid = 10; // Guid of the SensorTemplate in SensorTemplatesManager to instantiate
-		string result_file_name = 11; // Result file name without extention. Result files of the sensor will be based on this name.
+		string result_file_name = 11; // Result file name without extension. Result files of the sensor will be based on this name.
 		oneof properties {
 			CameraProperties camera_properties = 12; // To be filled if the sensor_guid corresponds to a SensorTemplate of type CameraSensorTemplate
 			IrradianceProperties irradiance_properties = 13; // To be filled if the sensor_guid corresponds to a SensorTemplate of type IrradianceSensorTemplate
@@ -451,7 +451,7 @@ message Scene
 	{
 		enum PatternOperation {
 			PATTERN_OPERATION_UNDEFINED = 0; // Undefined pattern operation
-			PATTERN_OPERATION_REMOVE = 1; // Substract the pattern from the support body
+			PATTERN_OPERATION_REMOVE = 1; // Subtract the pattern from the support body
 			PATTERN_OPERATION_ADD_ON_SAME_MATERIAL = 2; // Add the pattern on the support body and keep its material
 			PATTERN_OPERATION_ADD_ON_DIFFERENT_MATERIAL = 3; // Add the pattern on the support body and use the pattern's material
 			PATTERN_OPERATION_ADD_IN = 4; // Add the pattern into the support body and use the pattern's material

--- a/src/ansys/api/speos/scene/v2/scene.proto
+++ b/src/ansys/api/speos/scene/v2/scene.proto
@@ -550,7 +550,7 @@ service SceneActions {
 
 // Request to LoadFile service
 message LoadFile_Request {
-	string guid = 1; // Guid of a ScenesManager element to update
+	string guid = 1; // Guid of a ScenesManager element to update. To force the creation of SensorTemplate v1 instead of v2, this metadata needs to be added to the Scene's metadata: ("ForceSensorTemplateV1", "").
     string file_uri = 2; // File uri (path or guid from FileTransferService)
 	string password = 3; // Password needed to open the speos lightbox file (only necessary if user protects the speos light box with a password)
 }

--- a/src/ansys/api/speos/scene/v2/scene.proto
+++ b/src/ansys/api/speos/scene/v2/scene.proto
@@ -550,9 +550,10 @@ service SceneActions {
 
 // Request to LoadFile service
 message LoadFile_Request {
-	string guid = 1; // Guid of a ScenesManager element to update. To force the creation of SensorTemplate v1 instead of v2, this metadata needs to be added to the Scene's metadata: ("ForceSensorTemplateV1", "").
+	string guid = 1; // Guid of a ScenesManager element to update.
     string file_uri = 2; // File uri (path or guid from FileTransferService)
 	string password = 3; // Password needed to open the speos lightbox file (only necessary if user protects the speos light box with a password)
+	map<string, uint32> force_version = 4; // Optional - To force the creation of SensorTemplate v1: ("SensorTemplateVersion", 1).
 }
 // Response to LoadFile service
 message LoadFile_Response {

--- a/src/ansys/api/speos/scene/v2/scene.proto
+++ b/src/ansys/api/speos/scene/v2/scene.proto
@@ -553,7 +553,7 @@ message LoadFile_Request {
 	string guid = 1; // Guid of a ScenesManager element to update.
     string file_uri = 2; // File uri (path or guid from FileTransferService)
 	string password = 3; // Password needed to open the speos lightbox file (only necessary if user protects the speos light box with a password)
-	map<string, uint32> force_version = 4; // Optional - To force the creation of SensorTemplate v1: ("SensorTemplateVersion", 1).
+	map<string, uint32> force_version = 4; // Optional - To force the creation of a specific version of an ObjectTemplate. Only compatible with SensorTemplate (example: ("SensorTemplateVersion", 1)).
 }
 // Response to LoadFile service
 message LoadFile_Response {


### PR DESCRIPTION
SceneActions::LoadFile
Possibility to force sensor template v1 by using the map field force_version in the LoadFile_Request.
Example: ("SensorTemplateVersion", 1)

This will allow the user to keep receiving SensorTemplate v1 when calling LoadFile on a Scene.
By default, SensorTemplate v2 are returned, when this metadata is not set.