### PR TITLE
[fix] Modify SceneActions LoadFile in order to return job properties (like stop conditions)

### DIFF
--- a/src/ansys/api/speos/scene/v2/scene.proto
+++ b/src/ansys/api/speos/scene/v2/scene.proto
@@ -557,11 +557,13 @@ service SceneActions {
 // Request to LoadFile service
 message LoadFile_Request {
 	string guid = 1; // Guid of a ScenesManager element to update
-    string file_uri = 2; // File uri (path or guid from FileTransferService)
+	string file_uri = 2; // File uri (path or guid from FileTransferService)
 	string password = 3; // Password needed to open the speos lightbox file (only necessary if user protects the speos light box with a password)
+	bool retrieve_job_properties = 5; // Optional - If set to true, the job properties will be retrieved and sent back in the LoadFile_Response. If not set or false, those data can't be retrieved.
 }
 // Response to LoadFile service
 message LoadFile_Response {
+	string job_guid = 1; // This job guid can be used to retrieve stop conditions and other information (like timeline start time, or automatic save frequency). Only set if retrieve_job_properties is set to true in the LoadFile_Request.
 }
 
 // Request to SaveFile service.

--- a/src/ansys/api/speos/scene/v2/scene.proto
+++ b/src/ansys/api/speos/scene/v2/scene.proto
@@ -560,11 +560,12 @@ message LoadFile_Request {
 	string file_uri = 2; // File uri (path or guid from FileTransferService)
 	string password = 3; // Password needed to open the speos lightbox file (only necessary if user protects the speos light box with a password)
 	map<string, uint32> force_version = 4; // Optional - To force the creation of a specific version of an ObjectTemplate. Only compatible with SensorTemplate (example: ("SensorTemplateVersion", 1)).
-	bool retrieve_job_properties = 5; // Optional - If set to true, the job properties will be retrieved and sent back in the LoadFile_Response. If not set or false, those data can't be retrieved.
 }
 // Response to LoadFile service
 message LoadFile_Response {
-	string job_guid = 1; // This job guid can be used to retrieve stop conditions and other information (like timeline start time, or automatic save frequency). Only set if retrieve_job_properties is set to true in the LoadFile_Request.
+	oneof job {
+		ansys.api.speos.job.v2.Job job_v2 = 1; // Job data corresponding to the file loaded. Example of interesting data present in the job: stop conditions, automatic save frequency, timeline activation.
+	}
 }
 
 // Request to SaveFile service.

--- a/src/ansys/api/speos/scene/v2/scene.proto
+++ b/src/ansys/api/speos/scene/v2/scene.proto
@@ -1,5 +1,6 @@
 // (c) 2026 ANSYS, Inc. Unauthorized use, distribution, or duplication is prohibited.
 syntax = "proto3";
+import "ansys/api/speos/job/v2/job.proto";
 import "ansys/api/speos/results/v1/ray_path.proto";
 
 package ansys.api.speos.scene.v2;


### PR DESCRIPTION
Modify SceneActions LoadFile in order to return job properties.
In job properties can be found:
- Stop conditions
- Automatic save frequency
- Timeline activation with start time