### PR TITLE
Importation of gltf file with service LoadFile in SceneAction

### DIFF
--- a/src/ansys/api/speos/scene/v2/scene.proto
+++ b/src/ansys/api/speos/scene/v2/scene.proto
@@ -546,7 +546,7 @@ message List_Response {
 
 // Actions available on a Scene
 service SceneActions {
-	// Load .speos, .SPEOSLightBox file
+	// Load .speos, .SPEOSLightBox, .gltf/.glb (version greater than or equal to 2) file
 	rpc LoadFile(LoadFile_Request) returns (LoadFile_Response) {} 
 	// Save .SPEOSLightBox file.
 	rpc SaveFile(SaveFile_Request) returns (SaveFile_Response) {} 

--- a/src/ansys/api/speos/scene/v2/scene.proto
+++ b/src/ansys/api/speos/scene/v2/scene.proto
@@ -546,7 +546,7 @@ message List_Response {
 
 // Actions available on a Scene
 service SceneActions {
-	// Load .speos, .SPEOSLightBox, .gltf/.glb (version greater than or equal to 2) file
+	// Load a *.speos file, a *.SPEOSLightBox file, or a *.gltf/*.glb v2 file or higher
 	rpc LoadFile(LoadFile_Request) returns (LoadFile_Response) {} 
 	// Save .SPEOSLightBox file.
 	rpc SaveFile(SaveFile_Request) returns (SaveFile_Response) {} 


### PR DESCRIPTION
The service LoadFile in SceneAction handle the gltf file (.gltf and glb) with version greater than or equal to 2