### PR TITLE
fix: Scene - HumanEyeProperties - Use axis_system and focal instead o…

### DIFF
--- a/src/ansys/api/speos/scene/v2/scene.proto
+++ b/src/ansys/api/speos/scene/v2/scene.proto
@@ -362,9 +362,8 @@ message Scene
 			}
 		}
 		message HumanEyeProperties {
-			repeated double eye_point = 1; // Position of the observer (Ox Oy Oz).
-			repeated double top_direction = 2; // Top direction of the observer (Vx Vy Vz). The top_direction must be orthogonal to "eye_point - target_point" direction.
-			repeated double target_point = 3; // Position of the target point (Ox Oy Oz).
+			repeated double axis_system = 1; // (Ox Oy Oz Xx Xy Xz Yx Yy Yz Zx Zy Zz). O corresponds to the observer (eye point), Y corresponds to the top direction, Z corresponds to the sight direction. The coordinate system must be orthonormal.
+			double focal = 2; // Focal length (mm).
 			oneof layer_type {
 				LayerTypeNone layer_type_none = 4; // Layer type : None.
 				LayerTypeSource layer_type_source = 5; // Layer type : Source.


### PR DESCRIPTION
Scene - HumanEyeProperties
Use axis_system and focal instead of eye_point, target_point and top direction.
This harmonizes the human eye properties with other sensors properties.