### PR TITLE
fix: Immersive and Observer sensors - correction of axis system comment

### DIFF
--- a/src/ansys/api/speos/scene/v2/scene.proto
+++ b/src/ansys/api/speos/scene/v2/scene.proto
@@ -348,14 +348,14 @@ message Scene
 		}
 
 		message ObserverProperties{
-			repeated double axis_system = 1; // Position of the observed object/scene. (Ox Oy Oz Xx Xy Xz Yx Yy Yz Zx Zy Zz). X corresponds to Horizontal direction. Y corresponds to Vertical direction. The coordinate system must be orthonormal.
+			repeated double axis_system = 1; // Position of the observed object/scene. (Ox Oy Oz Xx Xy Xz Yx Yy Yz Zx Zy Zz). X corresponds to Vertical direction. Z corresponds to Horizontal direction. The coordinate system must be orthonormal.
 			oneof layer_type {
 				LayerTypeNone layer_type_none = 2; // Layer type : None.
 				LayerTypeSource layer_type_source = 3; // Layer type : Source.
 			}
 		}
 		message ImmersiveProperties {
-			repeated double axis_system = 1; // Position of the sensor (Ox Oy Oz Xx Xy Xz Yx Yy Yz Zx Zy Zz). X corresponds to Left direction, Y corresponds to Top direction, Z corresponds to Front direction. The coordinate system must be orthonormal.
+			repeated double axis_system = 1; // Position of the sensor (Ox Oy Oz Xx Xy Xz Yx Yy Yz Zx Zy Zz). X corresponds to Front direction, Y corresponds to Left direction, Z corresponds to Top direction. The coordinate system must be orthonormal.
 			oneof layer_type {
 				LayerTypeNone layer_type_none = 2; // Layer type : None.
 				LayerTypeSource layer_type_source = 3; // Layer type : Source.

--- a/src/ansys/api/speos/scene/v2/scene.proto
+++ b/src/ansys/api/speos/scene/v2/scene.proto
@@ -355,7 +355,7 @@ message Scene
 			}
 		}
 		message ImmersiveProperties {
-			repeated double axis_system = 1; // Position of the sensor (Ox Oy Oz Xx Xy Xz Yx Yy Yz Zx Zy Zz). X corresponds to Front direction. Y corresponds to Top direction. Z corresponds to Right direction. The coordinate system must be orthonormal.
+			repeated double axis_system = 1; // Position of the sensor (Ox Oy Oz Xx Xy Xz Yx Yy Yz Zx Zy Zz). X corresponds to Left direction, Y corresponds to Top direction, Z corresponds to Front direction. The coordinate system must be orthonormal.
 			oneof layer_type {
 				LayerTypeNone layer_type_none = 2; // Layer type : None.
 				LayerTypeSource layer_type_source = 3; // Layer type : Source.

--- a/src/ansys/api/speos/scene/v2/scene.proto
+++ b/src/ansys/api/speos/scene/v2/scene.proto
@@ -348,7 +348,7 @@ message Scene
 		}
 
 		message ObserverProperties{
-			repeated double axis_system = 1; // Position of the observed object/scene. (Ox Oy Oz Xx Xy Xz Yx Yy Yz Zx Zy Zz). X corresponds to Vertical direction. Z corresponds to Horizontal direction. The coordinate system must be orthonormal.
+			repeated double axis_system = 1; // Position of the observed object/scene. (Ox Oy Oz Xx Xy Xz Yx Yy Yz Zx Zy Zz). X corresponds to Horizontal direction. Z corresponds to Vertical direction. The coordinate system must be orthonormal.
 			oneof layer_type {
 				LayerTypeNone layer_type_none = 2; // Layer type : None.
 				LayerTypeSource layer_type_source = 3; // Layer type : Source.


### PR DESCRIPTION
Immersive and Observer - fix comment regarding axis system

- Immersive
  - The proto comment mentioned :
// Position of the sensor (Ox Oy Oz Xx Xy Xz Yx Yy Yz Zx Zy Zz).
X corresponds to Front direction.
Y corresponds to Top direction.
Z corresponds to Right direction.
  - The correct sentence is:
X corresponds to Front direction.
Y corresponds to **_Left_** direction.
Z corresponds to **_Top_** direction.

- Observer
  - The proto comment mentioned :
// Position of the observed object/scene. (Ox Oy Oz Xx Xy Xz Yx Yy Yz Zx Zy Zz).
X corresponds to Horizontal direction.
Y corresponds to Vertical direction.
  - The correct sentence is:
X corresponds to Horizontal direction.
**_Z_** corresponds to Vertical direction.